### PR TITLE
shadow blocks in Basic - plus reorg of the Basic category 

### DIFF
--- a/ui/src/blocks/basic/definitions.ts
+++ b/ui/src/blocks/basic/definitions.ts
@@ -47,6 +47,7 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+//   deprecated
   Blocks['while_true'] = {
     init: function () {
       this.appendDummyInput()
@@ -73,6 +74,7 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+//   deprecated
   Blocks['if'] = {
     init: function () {
       this.appendDummyInput()
@@ -119,6 +121,7 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+//   deprecated
   Blocks['ifcroc'] = {
     init: function () {
       this.appendDummyInput()
@@ -186,6 +189,7 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+//   deprecated
   Blocks['ifequals'] = {
     init: function () {
       this.appendDummyInput()
@@ -228,6 +232,7 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+//   deprecated
   Blocks['elif'] = {
     init: function () {
       this.appendDummyInput()
@@ -274,8 +279,10 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
   Blocks['whileout'] = {
     init: function () {
       this.appendDummyInput()
-        .appendField('while')
-        .appendField(new Blockly.FieldTextInput(''), '1')
+        .appendField('while');
+      this.appendValueInput("cond")
+        .setCheck(null);
+      this.appendDummyInput()
         .appendField(':');
       this.appendStatementInput('DO')
         .appendField('');
@@ -373,6 +380,7 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+//   deprecated
   Blocks['greater'] = {
     init: function () {
       this.appendDummyInput()
@@ -393,9 +401,10 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
 
   Blocks['ifinline'] = {
     init: function () {
-      this.appendValueInput('iftext')
-        .setCheck(null)
+      this.appendDummyInput()
         .appendField('if');
+      this.appendValueInput("iftext")
+        .setCheck(null);
       this.appendDummyInput()
         .appendField(':');
       this.appendStatementInput('ifstate')
@@ -423,9 +432,10 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
 
   Blocks['elifinline'] = {
     init: function () {
+      this.appendDummyInput()
+        .appendField('elif');
       this.appendValueInput('iftext')
         .setCheck(null)
-        .appendField('elif');
       this.appendDummyInput()
         .appendField(':');
       this.appendStatementInput('ifstate')
@@ -455,10 +465,28 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
 
   Blocks['internal'] = {
     init: function() {
+        // should you translate to other languages
+        // var rtlOperators = [
+        //     // ['=', 'EQ'],
+        //     // ['\u2260', 'NEQ'],
+        //     ['\u200F<\u200F', 'LT'],
+        //     ['\u200F\u2264\u200F', 'LTE'],
+        //     ['\u200F>\u200F', 'GT'],
+        //     ['\u200F\u2265\u200F', 'GTE']
+        //   ];
+          var ltrOperators = [
+            ['==', '=='],
+            ['!=', '!='],
+            ['<', '<'],
+            ['<=', '<='],
+            ['>', '>'],
+            ['=>', '=>']
+          ];
+          var OPERATORS = ltrOperators;
       this.appendValueInput("first")
           .setCheck(null);
       this.appendDummyInput()
-          .appendField(new Blockly.FieldTextInput("=="), "choose");
+          .appendField(new Blockly.FieldDropdown(OPERATORS), "choose")
       this.appendValueInput("last")
           .setCheck(null);
       this.setInputsInline(true);

--- a/ui/src/blocks/basic/generators.ts
+++ b/ui/src/blocks/basic/generators.ts
@@ -132,16 +132,15 @@ export default function define(Python: Blockly.BlockGenerators) {
 
   Python['df'] = function (block) {
     const text_def = block.getFieldValue('def');
-    // TODO: Assemble Python into code variable.
     const code = text_def + '()\n';
     return code;
   };
 
   Python['whileout'] = function (block) {
-    const text_1 = block.getFieldValue('1');
+    var text_1 = Blockly.Python.valueToCode(block, 'cond', Blockly.Python.ORDER_ATOMIC)
+    || 'True';
     let branch = Blockly.Python.statementToCode(block, 'DO');
     branch = Blockly.Python.addLoopTrap(branch, block.id) || Blockly.Python.PASS;
-    // TODO: Assemble Python into code variable.
     const code = 'while ' + text_1 + ':\n' + branch;
     return code;
   };
@@ -215,9 +214,7 @@ export default function define(Python: Blockly.BlockGenerators) {
   Python['ifinline'] = function (block) {
     let branch = Blockly.Python.statementToCode(block, 'ifstate');
     branch = Blockly.Python.addLoopTrap(branch, block.id) || Blockly.Python.PASS;
-    const value_iftext = Blockly.Python.valueToCode(block, 'iftext', Blockly.Python.ORDER_ATOMIC);
-    // const statements_ifstate = Blockly.Python.statementToCode(block, 'ifstate');
-    // TODO: Assemble Python into code variable.
+    const value_iftext = Blockly.Python.valueToCode(block, 'iftext', Blockly.Python.ORDER_ATOMIC) || 'True';
     const code = 'if ' + value_iftext + ':\n' + branch;
     return code;
   };

--- a/ui/src/blocks/basic/toolbox.xml
+++ b/ui/src/blocks/basic/toolbox.xml
@@ -1,32 +1,65 @@
 <category name="Basic" colour="336">
+  <label text="Imports:"></label>
   <block type="import_microbit"></block>
   <block type="import_math"></block>
+  <block type="random"></block>
   <block type="import_audio"></block>
   <block type="print"></block>
   <block type="sleep"></block>
-  <block type="random"></block>
-  <block type="while_true"></block>
   <block type="equalsblock"></block>
-  <block type="ifinline"></block>
-  <block type="elifinline"></block>
-  <block type="internal"></block>
-  <block type="if"></block>
+  <!-- <block type="while_true"></block> -->
+  <label text="Test:"></label>
+  <block type="internal">
+      <value name="first">
+        <shadow type="textinline">
+          <field name="text">0</field>
+        </shadow>
+      </value>
+      <value name="last">
+        <shadow type="textinline">
+          <field name="text">0</field>
+        </shadow>
+      </value>
+  </block>
+
+  <block type="whileout">
+    <value name="cond">
+      <shadow type="textinline">
+        <field name="text">True</field>
+      </shadow>
+    </value>
+  </block>
+
+  <block type="ifinline">
+    <value name="iftext">
+      <shadow type="textinline">
+        <field name="text">True</field>
+      </shadow>
+    </value>
+  </block>
+  <block type="elifinline">
+    <value name="iftext">
+      <shadow type="textinline">
+        <field name="text">True</field>
+      </shadow>
+    </value>
+  </block>
+  <block type="else"></block>
+  <!-- <block type="if"></block> -->
   <block type="typeanything"></block>
   <block type="textinline"></block>
   <block type="varinlines"></block>
   <block type="define"></block>
   <block type="df"></block>
   <block type="for"></block>
-  <block type="elif"></block>
-  <block type="else"></block>
+  <!-- <block type="elif"></block> -->
   <block type="pass"></block>
   <block type="class"></block>
   <block type="varprint"></block>
-  <block type="ifcroc"></block>
+  <!-- <block type="ifcroc"></block> -->
   <block type="varminus"></block>
   <block type="advancedforloops"></block>
-  <block type="ifequals"></block>
+  <!-- <block type="ifequals"></block> -->
   <block type="return2"></block>
-  <block type="whileout"></block>
-  <block type="greater"></block>
+  <!-- <block type="greater"></block> -->
 </category>


### PR DESCRIPTION
I am submitting this PR as I think it will improve Edublocks for Microbit, but everything in here is up for discussion.

1. I implemented shadow blocks in the If block. This means we no longer need a variety of **if** blocks. One is enough

Now, the same **if** block is used for these structures: 
(note I've done the same treatment to the elif block)

user entered text:
![shadowblock1](https://user-images.githubusercontent.com/4965628/43976658-719b270e-9caf-11e8-86ac-00172d6b7ed9.png)
dropping a block:
(note I've rewrote the comparison block to allow all types of comparisons via a dropdown menu)
![shadowblock2](https://user-images.githubusercontent.com/4965628/43976697-8df65734-9caf-11e8-8fa3-78abe8544e7c.png)

2. I did the same treatment to the While block:
These screenshots show the exact same while block edited in place for various needs

default block:
![while1](https://user-images.githubusercontent.com/4965628/43976969-9b5392c4-9cb0-11e8-94de-0cbfc50a58d9.png)

dropping another block:
![while2](https://user-images.githubusercontent.com/4965628/43976979-9f982908-9cb0-11e8-9742-2751fc792ebd.png)

Editing in place:
![while3](https://user-images.githubusercontent.com/4965628/43976993-aa0c8834-9cb0-11e8-9c15-88b7772670cb.png)

2. Because only one of each **if**  or **while** block is needed now, I reworked the flyout to look like this:
![flyout](https://user-images.githubusercontent.com/4965628/43976809-f68abe70-9caf-11e8-9102-4f92a4afd27c.png)
The bottom part of the flyout hasn't changed yet apart from the no longer needed blocks being removed.
 
2.1 I've put all the imports at the top
2.2 I've put the if/elif/else blocks in an order similar to what would be found in code
2.3 I've put the comparison block just at the top of the section that requires comparison. Users do not have to use it as the code can be typed in place instead but for younger kids afraid of typing, now they have a drag/drop approach instead.

The blocks that I have removed are still available in code so it's backward compatible with programs already written. The deprecated blocks are simply no longer accessible from the flyout but they do still work.

3. May I also suggest integrating the standard math blocks, and the variable category? If there's interest, I can help out on those too.

I'm open to discussions on these features. A brief chat with @JoshuaLowe1002  yesterday implied those changes would be welcome.  

Nicole
Dexter Industries