### PR TITLE
Favour the use of milliseconds

### DIFF
--- a/ui/src/blocks/gigglebot/definitions.ts
+++ b/ui/src/blocks/gigglebot/definitions.ts
@@ -34,6 +34,8 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
               .appendField(", seconds=");
           this.appendValueInput("seconds")
               .setCheck(null);
+          this.appendDummyInput()
+              .appendField(")");
           this.setInputsInline(true);
           this.setPreviousStatement(true, null);
           this.setNextStatement(true, null);
@@ -61,9 +63,12 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
           this.appendDummyInput()
               .appendField("turn (")
               .appendField(new Blockly.FieldDropdown([["LEFT","LEFT"], ["RIGHT","RIGHT"]]), "dir")
-              .appendField(", seconds=")
-              .appendField(new Blockly.FieldNumber(0, 0), "seconds")
+              .appendField(", seconds=");
+          this.appendValueInput("seconds")
+              .setCheck(null);
+          this.appendDummyInput()
               .appendField(")");
+          this.setInputsInline(true);
           this.setPreviousStatement(true, null);
           this.setNextStatement(true, null);
           this.setColour(gigglebot_HUE);

--- a/ui/src/blocks/gigglebot/generators.ts
+++ b/ui/src/blocks/gigglebot/generators.ts
@@ -49,7 +49,7 @@ export default function define(Python: Blockly.BlockGenerators) {
     Python['set_servo'] = function(block) {
         var dropdown_which = block.getFieldValue('which');
         var number_degrees = block.getFieldValue('degrees');
-        var code = 'drive('+dropdown_which+', degrees='+number_degrees+')\n';
+        var code = 'set_servo('+dropdown_which+', degrees='+number_degrees+')\n';
         return code;
     };
 

--- a/ui/src/blocks/gigglebot/gigglebot.py
+++ b/ui/src/blocks/gigglebot/gigglebot.py
@@ -111,7 +111,7 @@ def set_eyes(which=BOTH, R=0, G=0, B=10):
     neopixelstrip.show()
 
 def set_eye_color_on_start():
-    if _read16(GET_VOLTAGE_BATTERY) < 3600:
+    if _read16(GET_VOLTAGE_BATTERY) < 3400:
         neopixelstrip[0] = LOW_VOLTAGE_EYE_COLOR
         neopixelstrip[1]= LOW_VOLTAGE_EYE_COLOR
     else:

--- a/ui/src/blocks/gigglebot/gigglebot.py
+++ b/ui/src/blocks/gigglebot/gigglebot.py
@@ -1,6 +1,5 @@
 import neopixel
 import microbit
-import time
 
 GET_FIRMWARE_VERSION = 1
 # GET_MANUFACTURER = 2
@@ -54,7 +53,7 @@ def volt():
 def drive(dir=FORWARD, seconds=-1):
     _write8(SET_MOTOR_POWERS, motor_power_left*dir, motor_power_right*dir)
     if seconds >= 0:
-        time.sleep(seconds)
+        microbit.sleep(seconds)
         stop()
 
 def turn(dir=LEFT, seconds=-1):
@@ -63,7 +62,7 @@ def turn(dir=LEFT, seconds=-1):
     if dir==RIGHT:
         _write8(SET_MOTOR_POWERS, 0, motor_power_right)
     if seconds >= 0:
-        time.sleep(seconds)
+        microbit.sleep(seconds)
         stop()        
 
 def set_speed(power_left, power_right):


### PR DESCRIPTION
On a pristine microbit, one that hasn't gone through the Mu Editor, 
sleep() uses milliseconds and not seconds. 
Change the corresponding blocks to use milliseconds.