### PR TITLE
Microbit scratch blocks

### DIFF
--- a/ui/src/blocks/accelerometer/definitions.ts
+++ b/ui/src/blocks/accelerometer/definitions.ts
@@ -61,5 +61,53 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+var gesture_dropdown = [
+    ["'shake'", "'shake'"],
+    ["'up'","'up'"], 
+    ["'down'","'down'"], 
+    ["'left'","'left'"],
+    ["'right'", "'right'"],
+    ["'face up'", "'face up'"],
+    ["'face down'", "'face down'"],
+    ["'freefall'", "'freefall'"],
+    ["'3g'", "'3g'"],
+    ["'6g'", "'6g'"],
+    ["'8g'", "'8g'"],
+    ];
+  Blockly.Blocks['accgestures'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField(new Blockly.FieldDropdown(gesture_dropdown), "gestures");
+      this.setOutput(true,"String");
+      this.setColour("#E57E16","#E57E16","#b87533");
+   this.setTooltip("list of possible gestures");
+   this.setHelpUrl("");
+    }
+  };
+
+Blockly.Blocks["acccurrentgesture"] = {
+    init: function() {
+      this.appendDummyInput()
+        .appendField("accelerometer.current_gesture()")
+      this.setOutput(true, "String");
+      this.setColour("#E57E16","#E57E16","#b87533");
+      this.setTooltip("reads the current gesture");
+    }
+  };
+
+Blockly.Blocks['accget'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField("accelerometer.")
+        .appendField(new Blockly.FieldDropdown([
+          ["get_x()", "get_x()"],
+          ["get_y()", "get_y()"],
+          ["get_z()", "get_z()"]
+        ]), "axis");
+      this.setOutput(true,"Number");
+      this.setColour("#E57E16","#E57E16","#b87533");
+      this.setTooltip("reads the current movement on the selected axis");
+    }
+  }
 
 }

--- a/ui/src/blocks/accelerometer/generators.ts
+++ b/ui/src/blocks/accelerometer/generators.ts
@@ -26,4 +26,19 @@ export default function define(Python: Blockly.BlockGenerators) {
     return [code, Blockly.Python.ORDER_ATOMIC];
   };
 
+  Python['accgestures'] = function (block) {
+    const text_gesture = block.getFieldValue('gestures');
+    return [text_gesture, Blockly.Python.ORDER_ATOMIC];
+  };
+
+  Python['acccurrentgesture'] = function (block) {
+    const code = 'accelerometer.current_gesture()';
+    return [code, Blockly.Python.ORDER_ATOMIC];
+  };
+
+  Python['accget'] = function (block) {
+    const text_axis = block.getFieldValue('axis');
+    const code = 'accelerometer.' +text_axis;
+    return [code, Blockly.Python.ORDER_ATOMIC];
+  }; 
 }

--- a/ui/src/blocks/accelerometer/toolbox.xml
+++ b/ui/src/blocks/accelerometer/toolbox.xml
@@ -2,16 +2,19 @@
     <label text="Accelerometer" web-class="myLabelStyle"></label>
     <block type="accisgesturenew">
     <value name="text">
-      <shadow type="textinline">
-        <field name="text">'shake'</field>
+      <shadow type="accgestures">
+        <field name="gestures">'shake'</field>
       </shadow>
     </value>
   </block>
     <block type="accwasgesturenew">
     <value name="text">
-      <shadow type="textinline">
-        <field name="text">'shake'</field>
+      <shadow type="accgestures">
+        <field name="gestures">'shake'</field>
       </shadow>
     </value>
   </block>
+  <block type="accgestures"></block>
+  <block type="acccurrentgesture"></block>
+  <block type="accget"></block>
 </category> 

--- a/ui/src/blocks/basic/definitions.ts
+++ b/ui/src/blocks/basic/definitions.ts
@@ -417,10 +417,14 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
   Blocks['define'] = {
     init: function () {
       this.appendDummyInput()
-        .appendField('def ')
-        .appendField(new Blockly.FieldTextInput(''), '1')
-        .appendField('(')
-        .appendField(new Blockly.FieldTextInput(''), '2')
+        .appendField('def ');
+      this.appendValueInput('1')
+        .setCheck(null);
+      this.appendDummyInput()
+        .appendField('(');
+      this.appendValueInput('2')
+        .setCheck(null);
+      this.appendDummyInput()
         .appendField('):');
       this.appendStatementInput('DO')
         .setCheck(null);
@@ -473,7 +477,9 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
   Blocks['typeanything'] = {
     init: function() {
       this.appendDummyInput()
-          .appendField(new Blockly.FieldTextInput(""), "stuff");
+          .appendField("# freecode\n");
+      this.appendDummyInput()   
+          .appendField(new Blockly.FieldTextInput("       "), "stuff");
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour("#ff0066","#ff0066","#b3235a");

--- a/ui/src/blocks/basic/generators.ts
+++ b/ui/src/blocks/basic/generators.ts
@@ -198,8 +198,8 @@ export default function define(Python: Blockly.BlockGenerators) {
   };
 
   Python['define'] = function (block) {
-    const text_1 = block.getFieldValue('1');
-    const text_2 = block.getFieldValue('2');
+    const text_1 = Blockly.Python.valueToCode(block, '1', Blockly.Python.ORDER_ATOMIC)
+    const text_2 = Blockly.Python.valueToCode(block, '2', Blockly.Python.ORDER_ATOMIC)
     let branch = Blockly.Python.statementToCode(block, 'DO');
     branch = Blockly.Python.addLoopTrap(branch, block.id) || Blockly.Python.PASS;
     // const statements_name = Blockly.Python.statementToCode(block, 'NAME');
@@ -237,7 +237,7 @@ export default function define(Python: Blockly.BlockGenerators) {
   Python['typeanything'] = function(block) {
     var text_stuff = block.getFieldValue('stuff');
     // TODO: Assemble Python into code variable.
-    var code = text_stuff+ '\n';
+    var code = "# freecode\n"+ text_stuff+ '\n';
     return code;
   };
 

--- a/ui/src/blocks/basic/toolbox.xml
+++ b/ui/src/blocks/basic/toolbox.xml
@@ -71,7 +71,18 @@
   <block type="typeanything"></block>
   <block type="textinline"></block>
   <block type="varinlines"></block>
-  <block type="define"></block>
+  <block type="define">
+    <value name="1">
+      <shadow type="textinline">
+        <field name="text">    </field>
+      </shadow>
+    </value>
+    <value name="2">
+      <shadow type="textinline">
+        <field name="text">    </field>
+      </shadow>
+    </value>
+  </block>
   <block type="df"></block>
   <block type="for"></block>
   <!-- <block type="elif"></block> -->


### PR DESCRIPTION
Some new blocks under "accelerator" and some changes to existing blocks.
These blocks allow the user to discover gestures instead of having to remember them and type them up. 
![acc](https://user-images.githubusercontent.com/4965628/46565884-1f1e2200-c8e3-11e8-9fe7-c390b0bc1636.png)

Some changes to Basic blocks:
Add a comment to the `typeanything` block to be more explicit as to what this block does. 
And the `define` block now takes shadow blocks. That way we can drop a variable as a parameter.
![basic](https://user-images.githubusercontent.com/4965628/46565894-5987bf00-c8e3-11e8-803b-26cfdc5ffe6f.png)

