### PR TITLE
added top hat block

### DIFF
--- a/ui/src/blockly-core.d.ts
+++ b/ui/src/blockly-core.d.ts
@@ -1446,7 +1446,9 @@ declare module Blockly.Events {
 
 declare module Blockly {
 
-    class BlockSvg extends BlockSvg__Class { }
+    class BlockSvg extends BlockSvg__Class {
+      static START_HAT: boolean;
+}
     /** Fake class which should be extended to avoid inheriting static properties */
     class BlockSvg__Class extends Blockly.Block__Class  { 
     

--- a/ui/src/blocks/circuitpython/basic/definitions.ts
+++ b/ui/src/blocks/circuitpython/basic/definitions.ts
@@ -14,6 +14,19 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
     },
   };
 
+  Blocks['events_start_here'] = { 
+    init: function() {
+      this.appendDummyInput()
+          .appendField("# Start code here"); 
+          // other option is "#!/usr/bin/python3"
+      this.setNextStatement(true, null);
+      this.setColour("#F8CB3F");
+      Blockly.BlockSvg.START_HAT = true;
+      // this.setTooltip(DexterMsg.Blockly.Blocks.Events.TOOLTIP_START_BLOCK);
+      // this.setHelpUrl('');
+    }
+  };
+
   Blocks['import_time'] = {
     init: function () {
       this.appendDummyInput()

--- a/ui/src/blocks/circuitpython/basic/generators.ts
+++ b/ui/src/blocks/circuitpython/basic/generators.ts
@@ -4,6 +4,11 @@ export default function define(Python: Blockly.BlockGenerators) {
     return code;
   };
 
+  Python['events_start_here'] = function (block) {
+    const code = '# Start code here\n';
+    return code;
+  };
+
   Python['import_time'] = function (block) {
     const code = 'import time\n';
     return code;

--- a/ui/src/blocks/microbit/basic/definitions.ts
+++ b/ui/src/blocks/microbit/basic/definitions.ts
@@ -3,6 +3,20 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
   var maincolour = "#ff0066";
   var bordercolour = "#b3235a";
   var inputcolour = "#ff0066";
+
+  Blocks['events_start_here'] = { 
+    init: function() {
+      this.appendDummyInput()
+          .appendField("# Start code here"); 
+          // other option is "#!/usr/bin/python3"
+      this.setNextStatement(true, null);
+      this.setColour("#F8CB3F");
+      Blockly.BlockSvg.START_HAT = true;
+      // this.setTooltip(DexterMsg.Blockly.Blocks.Events.TOOLTIP_START_BLOCK);
+      // this.setHelpUrl('');
+    }
+  };
+
   Blocks['import_microbit'] = {
     init: function () {
       this.appendDummyInput()

--- a/ui/src/blocks/microbit/basic/generators.ts
+++ b/ui/src/blocks/microbit/basic/generators.ts
@@ -4,6 +4,11 @@ export default function define(Python: Blockly.BlockGenerators) {
     return code;
   };
 
+  Python['events_start_here'] = function (block) {
+    const code = '# Start code here\n';
+    return code;
+  };
+
   Python['import_signal'] = function (block) {
     const code = 'from signal import pause\n';
     return code;

--- a/ui/src/blocks/pi/basic/definitions.ts
+++ b/ui/src/blocks/pi/basic/definitions.ts
@@ -3,6 +3,19 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
   var maincolour = "#ff0066";
   var bordercolour = "#b3235a";
   var inputcolour = "#ff0066";
+
+  Blockly.Blocks['events_start_here'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Start code"); 
+          // other option is "#!/usr/bin/python3"
+      this.setNextStatement(true, null);
+      this.setColour("#F8CB3F");
+      // this.setTooltip(DexterMsg.Blockly.Blocks.Events.TOOLTIP_START_BLOCK);
+      // this.setHelpUrl('');
+    }
+  };
+
   Blocks['import_time'] = {
     init: function () {
       this.appendDummyInput()

--- a/ui/src/blocks/pi/basic/definitions.ts
+++ b/ui/src/blocks/pi/basic/definitions.ts
@@ -4,10 +4,10 @@ export default function define(Blocks: Blockly.BlockDefinitions) {
   var bordercolour = "#b3235a";
   var inputcolour = "#ff0066";
 
-  Blockly.Blocks['events_start_here'] = {
+  Blocks['events_start_here'] = { 
     init: function() {
       this.appendDummyInput()
-          .appendField("Start code"); 
+          .appendField("# Start code"); 
           // other option is "#!/usr/bin/python3"
       this.setNextStatement(true, null);
       this.setColour("#F8CB3F");

--- a/ui/src/blocks/pi/basic/generators.ts
+++ b/ui/src/blocks/pi/basic/generators.ts
@@ -8,7 +8,7 @@ export default function define(Python: Blockly.BlockGenerators) {
   Python['import_time'] = function (block) {
     const code = 'import time\n';
     return code;
-  };
+  }; 
 
   Python['import_signal'] = function (block) {
     const code = 'from signal import pause\n';

--- a/ui/src/blocks/pi/basic/generators.ts
+++ b/ui/src/blocks/pi/basic/generators.ts
@@ -1,4 +1,10 @@
 export default function define(Python: Blockly.BlockGenerators) {
+
+  Python['events_start_here'] = function (block) {
+    const code = '# Start code\n';
+    return code;
+  };
+  
   Python['import_time'] = function (block) {
     const code = 'import time\n';
     return code;

--- a/ui/src/blocks/web/imports/definitions.ts
+++ b/ui/src/blocks/web/imports/definitions.ts
@@ -1,5 +1,18 @@
 export default function define(Blocks: Blockly.BlockDefinitions) {
 
+  Blocks['events_start_here'] = { 
+    init: function() {
+      this.appendDummyInput()
+          .appendField("# Start code here"); 
+          // other option is "#!/usr/bin/python3"
+      this.setNextStatement(true, null);
+      this.setColour("#F8CB3F");
+      Blockly.BlockSvg.START_HAT = true;
+      // this.setTooltip(DexterMsg.Blockly.Blocks.Events.TOOLTIP_START_BLOCK);
+      // this.setHelpUrl('');
+    }
+  };
+
   
   Blocks['import_time'] = {
     init: function () {

--- a/ui/src/blocks/web/imports/generators.ts
+++ b/ui/src/blocks/web/imports/generators.ts
@@ -1,4 +1,10 @@
 export default function define(Python: Blockly.BlockGenerators) {
+
+  Python['events_start_here'] = function (block) {
+    const code = '# Start code here\n';
+    return code;
+  };
+
   Python['import_time'] = function (block) {
     const code = 'import time\n';
     return code;

--- a/ui/src/views/BlocklyView.tsx
+++ b/ui/src/views/BlocklyView.tsx
@@ -77,6 +77,9 @@ export default class BlocklyView extends Component<BlocklyViewProps, {}> {
 
       Blockly.svgResize(this.workspace);
 
+      // disable blocks that aren't attached to the start block
+      this.workspace.addChangeListener(Blockly.Events.disableOrphans);
+      
       Blockly.Generator.prototype.INDENT = '\t';
 
       this.setXml(this.xml);
@@ -102,14 +105,50 @@ export default class BlocklyView extends Component<BlocklyViewProps, {}> {
   }
 
   private setXml(xml: string | null) {
+
     if (!this.workspace) {
       throw new Error('No workspace!');
     }
 
     this.workspace.clear();
 
+    // console.log("in setXML")
+    
+    var start = null;
+    var new_xml = '<xml xmlns="https://developers.google.com/blockly/xml"><block type="events_start_here" id="DI_start_here" x="'+ 100 + '" y="43" deletable="false" movable="false"></block></xml>';
+
     if (typeof xml === 'string') {
-      const textToDom = Blockly.Xml.textToDom(xml);
+      // check if we have a top hat
+      start = xml.search("DI_start_here");
+
+      if (start < 0) {
+        // console.log("top hat not found")
+        var first_block_position = xml.search("<block")
+        var start_block_xml = '<block type="events_start_here" id="DI_start_here" x="'+ 100 + '" y="43" deletable="false" movable="false">'
+
+        if (first_block_position < 0)
+        // no block were found, we have an empty XML coming in 
+        {   
+          console.log("no blocks were found")
+          // new_xml will be used as is
+        } else {
+          // insert new top hat in the XML code
+          var pos_from_end_of_string = -1 * ("</xml>".length)
+          var new_xml = xml.slice(0, first_block_position) + start_block_xml + "<next>" + xml.slice(first_block_position, pos_from_end_of_string) + "</next></block>" + xml.slice(pos_from_end_of_string);
+        }
+        const textToDom = Blockly.Xml.textToDom(new_xml);
+        Blockly.Xml.domToWorkspace(textToDom, this.workspace);
+
+      } else {
+        // top hat found
+        // do not use new_xml, but use the provided xml as is
+        const textToDom = Blockly.Xml.textToDom(xml);
+        Blockly.Xml.domToWorkspace(textToDom, this.workspace);
+      }
+    }
+    else {
+      // opening a new file
+      const textToDom = Blockly.Xml.textToDom(new_xml);
       Blockly.Xml.domToWorkspace(textToDom, this.workspace);
     }
   }

--- a/ui/src/views/BlocklyView.tsx
+++ b/ui/src/views/BlocklyView.tsx
@@ -17,15 +17,15 @@ export default class BlocklyView extends Component<BlocklyViewProps, {}> {
   private workspace?: Blockly.WorkspaceSvg;
   private xml: string | null = null;
 
-  public componentWillReceiveProps(nextProps: BlocklyViewProps) {
+  public async componentWillReceiveProps(nextProps: BlocklyViewProps) {
     if (nextProps.visible) {
-      if (this.xml !== nextProps.xml) {
-        this.setXml(nextProps.xml);
-      }
-
       // Reload blockly if the extensions have changed
       if (!_.isEqual(this.props.extensionsActive, nextProps.extensionsActive)) {
         this.loadBlockly(nextProps.extensionsActive);
+      }
+
+      if (this.xml !== nextProps.xml) {
+        await this.setXml(nextProps.xml);
       }
     }
   }
@@ -81,8 +81,6 @@ export default class BlocklyView extends Component<BlocklyViewProps, {}> {
       this.workspace.addChangeListener(Blockly.Events.disableOrphans);
       
       Blockly.Generator.prototype.INDENT = '\t';
-
-      this.setXml(this.xml);
     }
   }
 


### PR DESCRIPTION
Added a 'Start Code' block. 
![image](https://user-images.githubusercontent.com/4965628/85643777-27903080-b663-11ea-86e1-078b0e13a34c.png)

The main advantage of having a top hat block is that disconnected blocks become disabled and do not generate code. This allows users more freedom in exploring various 'what if' scenarios.

![image](https://user-images.githubusercontent.com/4965628/85643915-805fc900-b663-11ea-80db-cad02b8623c3.png)

This supports backwards compatibility, as pre-existing code will get the top hat added automatically when they get loaded into the editor. 

Another option for the text inside the 'start code' block could be `#!/usr/bin/python3`  as this reflects an actual Python file and good habits, however it is a bit obscure for a beginner.